### PR TITLE
flaky test fix

### DIFF
--- a/_dotdot.py
+++ b/_dotdot.py
@@ -31,20 +31,31 @@ import sys
 
 __version__ = "1.1.0"
 
-_has_called = False
+_has_called = set([])
 
+original_sys_path = None
 
 def set_level_if_valid(level):
     global _has_called
-    if _has_called:
+    global original_sys_path
+    if not original_sys_path:
+        original_sys_path = sys.path[0]
+    if level in _has_called:
         return
-    _has_called = True
+    _has_called.add(level)
     path = sys.path[0]
     for i in range(level):
         path = os.path.dirname(path)
     sys.path[0] = path
 
-
+def restore_sys_path():
+    """
+    Restore the original system path
+    """
+    if not original_sys_path:
+        return
+    sys.path[0] = original_sys_path
+    
 def do_nothing():
     """
     Do nothing but just want Pycharm or anything else happy. :)

--- a/dot.py
+++ b/dot.py
@@ -36,4 +36,5 @@ from _dotdot import do_nothing
 
 __version__ = _dotdot.__version__
 
+_dotdot.restore_sys_path()
 _dotdot.set_level_if_valid(0)

--- a/dotdot.py
+++ b/dotdot.py
@@ -39,4 +39,5 @@ from _dotdot import do_nothing
 
 __version__ = _dotdot.__version__
 
+_dotdot.restore_sys_path()
 _dotdot.set_level_if_valid(1)

--- a/dotdotdot.py
+++ b/dotdotdot.py
@@ -39,4 +39,5 @@ from _dotdot import do_nothing
 
 __version__ = _dotdot.__version__
 
+_dotdot.restore_sys_path()
 _dotdot.set_level_if_valid(2)

--- a/dotdotdotdot.py
+++ b/dotdotdotdot.py
@@ -39,4 +39,5 @@ from _dotdot import do_nothing
 
 __version__ = _dotdot.__version__
 
+_dotdot.restore_sys_path()
 _dotdot.set_level_if_valid(3)

--- a/tests/test_dot.py
+++ b/tests/test_dot.py
@@ -9,10 +9,7 @@ DOTDOTDOTDOT = os.path.dirname(DOTDOTDOT)
 
 sys.path.append(DOTDOT)
 
-
 def test_dot():
     import dot
-    import dotdot
-    import dotdotdot
-    import dotdotdotdot
     assert sys.path[0] == DOT
+

--- a/tests/test_dotdot.py
+++ b/tests/test_dotdot.py
@@ -12,7 +12,5 @@ sys.path.append(DOTDOT)
 
 def test_dotdot():
     import dotdot
-    import dot
-    import dotdotdot
-    import dotdotdotdot
     assert sys.path[0] == DOTDOT
+

--- a/tests/test_dotdotdot.py
+++ b/tests/test_dotdotdot.py
@@ -12,8 +12,4 @@ sys.path.append(DOTDOT)
 
 def test_dotdotdot():
     import dotdotdot
-    import dotdot
-    import dot
-    import dotdotdot
-    import dotdotdotdot
     assert sys.path[0] == DOTDOTDOT

--- a/tests/test_dotdotdotdot.py
+++ b/tests/test_dotdotdotdot.py
@@ -12,8 +12,4 @@ sys.path.append(DOTDOT)
 
 def test_dotdotdotdot():
     import dotdotdotdot
-    import dotdotdot
-    import dotdot
-    import dot
-    import dotdotdot
     assert sys.path[0] == DOTDOTDOTDOT


### PR DESCRIPTION
Problem:
When you run every single test in directory tests, it passed, but when you run all of them at the same time, if will fail.
Why:
The _dot.py directly change the system path and will not restore it. So when you call multiple tests, the system path will be messed. 
Change:
1. Change how we flag whether the dot is called, we can call dotdot and dot and other dot files in one file and call all of them.
2. Restore the path everytime before call new dot, so the new path is consistent.
Result:
Passed with following commands:
```
pytest
pytest singletest
pytest --flake-finder
```
